### PR TITLE
Adds FastLED support

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -1,14 +1,14 @@
 
+#define USE_OCTOWS2811
+
 #include <OctoWS2811.h>
+#include <FastLED.h>
 #include "vector.h"
 #include "trng.h"
 #include "metrics.h"
 
-// Initialize LEDs.
-DMAMEM int display_memory[kLedsPerStrip * 6];
-int drawing_memory[kLedsPerStrip * 6];
-const int config = WS2811_GRB | WS2811_800kHz;
-OctoWS2811 leds(kLedsPerStrip, display_memory, drawing_memory, config);
+// allocate memory for leds
+CRGB leds[kLedsPerStrip * 6];
 
 // Random number to be loaded in setup and used to pick the animation.
 uint32_t random_number;
@@ -21,69 +21,75 @@ std::vector<int> color_palette_4;
 std::vector<int> color_palette_5;
 std::vector<int> color_palette_6;
 
-void setup() {
-  // Put your setup code here, to run once:
-  MakeMonoColorPalette(
-      RED /*=color*/,
-      100 /*=colors_len*/, &color_palette_1);
-  MakeFadedMonoColorPalette(
-      120 /*=color_hue*/,
-      0.2 /*=width_ratio*/, 0 /*=shift_ratio*/,
-      true /*=fade_into_black*/,
-      100 /*=colors_len*/, &color_palette_2);
-  MakeBiColorPalette(
-      BLUE /*=color_1*/, BLACK /*=color_2*/,
-      0.2 /*=width_ratio*/, 0 /*=shift_ratio*/,
-      100 /*=colors_len*/, &color_palette_3);
-  MakeFadedBiColorPalette(
-      120 /*=color_hue_1*/, 210 /*=color_hue_2*/,
-      0.5 /*=width_ratio*/, 0 /*=shift_ratio*/,
-      false /*=fade_into_black*/,
-      100 /*=colors_len*/, &color_palette_4);
-  MakeHueSweepPalette(
-      0 /*=min_hue*/, 360 /*=max_hue*/,
-      kSaturation /*=saturation*/,
-      kMidLightness /*=lightness*/,
-      0 /*=shift_ratio*/,
-      100 /*=colors_len*/, &color_palette_5);
-  MakeLightnessSweepPalette(
-      180 /*=hue*/,
-      kSaturation /*=saturation*/,
-      0 /*=min_lightness*/, 100 /*=max_lightness*/,
-      0 /*=shift_ratio*/,
-      100 /*=colors_len*/, &color_palette_6);
-  leds.begin();
+void setup()
+{
+    // initialize fast led with octows2811 controller
+    FastLED.addLeds<OCTOWS2811>(leds, kLedsPerStrip);
+    FastLED.setBrightness(32); // adjust brightness here!
 
-  // Setup RNG  
-  SIM_SCGC6 |= SIM_SCGC6_RNGA; // enable RNG
-  RNG_CR &= ~RNG_CR_SLP_MASK;
-  RNG_CR |= RNG_CR_HA_MASK;  // high assurance, not needed
-  random_number = trng(); 
+    // Put your setup code here, to run once:
+    MakeMonoColorPalette(
+        RED /*=color*/,
+        100 /*=colors_len*/, &color_palette_1);
+    MakeFadedMonoColorPalette(
+        120 /*=color_hue*/,
+        0.2 /*=width_ratio*/, 0 /*=shift_ratio*/,
+        true /*=fade_into_black*/,
+        100 /*=colors_len*/, &color_palette_2);
+    MakeBiColorPalette(
+        BLUE /*=color_1*/, BLACK /*=color_2*/,
+        0.2 /*=width_ratio*/, 0 /*=shift_ratio*/,
+        100 /*=colors_len*/, &color_palette_3);
+    MakeFadedBiColorPalette(
+        120 /*=color_hue_1*/, 210 /*=color_hue_2*/,
+        0.5 /*=width_ratio*/, 0 /*=shift_ratio*/,
+        false /*=fade_into_black*/,
+        100 /*=colors_len*/, &color_palette_4);
+    MakeHueSweepPalette(
+        0 /*=min_hue*/, 360 /*=max_hue*/,
+        kSaturation /*=saturation*/,
+        kMidLightness /*=lightness*/,
+        0 /*=shift_ratio*/,
+        100 /*=colors_len*/, &color_palette_5);
+    MakeLightnessSweepPalette(
+        180 /*=hue*/,
+        kSaturation /*=saturation*/,
+        0 /*=min_lightness*/, 100 /*=max_lightness*/,
+        0 /*=shift_ratio*/,
+        100 /*=colors_len*/, &color_palette_6);
+
+    // Setup RNG
+    SIM_SCGC6 |= SIM_SCGC6_RNGA; // enable RNG
+    RNG_CR &= ~RNG_CR_SLP_MASK;
+    RNG_CR |= RNG_CR_HA_MASK; // high assurance, not needed
+    random_number = trng();
 }
 
-void loop() {
-  // Put your main code here, to run repeatedly:
-  switch (random_number % 3) {
+void loop()
+{
+    // Put your main code here, to run repeatedly:
+    switch (random_number % 3)
+    {
     case 0:
-      RotateVertical(
-          kVerticalRotationFreq, kLedRefreshFreq,
-          color_palette_1, true /*=move_up*/);
-      RotateVertical(
-          kVerticalRotationFreq, kLedRefreshFreq,
-          color_palette_1, false /*=move_up*/);
+        RotateVertical(
+            kVerticalRotationFreq, kLedRefreshFreq,
+            color_palette_1, true /*=move_up*/);
+        RotateVertical(
+            kVerticalRotationFreq, kLedRefreshFreq,
+            color_palette_1, false /*=move_up*/);
     case 1:
-      RotatePolar(
-          kPolarRotationFreq, kLedRefreshFreq,
-          color_palette_1, true /*=clockwise*/);
-      RotatePolar(
-          kPolarRotationFreq, kLedRefreshFreq,
-          color_palette_1, false /*=clockwise*/);
+        RotatePolar(
+            kPolarRotationFreq, kLedRefreshFreq,
+            color_palette_1, true /*=clockwise*/);
+        RotatePolar(
+            kPolarRotationFreq, kLedRefreshFreq,
+            color_palette_1, false /*=clockwise*/);
     case 3:
-      RainbowWave(
-          kRainbowLightnessFreq, kRainbowHueFreq, kLedRefreshFreq,
-          kLowLightness, kMidLightness, true /*=red_to_violet*/);
-      RainbowWave(
-          kRainbowLightnessFreq, kRainbowHueFreq, kLedRefreshFreq,
-          kLowLightness, kMidLightness, false /*=red_to_violet*/);
-  }
+        RainbowWave(
+            kRainbowLightnessFreq, kRainbowHueFreq, kLedRefreshFreq,
+            kLowLightness, kMidLightness, true /*=red_to_violet*/);
+        RainbowWave(
+            kRainbowLightnessFreq, kRainbowHueFreq, kLedRefreshFreq,
+            kLowLightness, kMidLightness, false /*=red_to_violet*/);
+    }
 }

--- a/main/metrics.h
+++ b/main/metrics.h
@@ -4,21 +4,21 @@
 #ifndef MAIN_METRICS_H_
 #define MAIN_METRICS_H_
 
-#define RED    0xFF0000
-#define GREEN  0x00FF00
-#define BLUE   0x0000FF
+#define RED 0xFF0000
+#define GREEN 0x00FF00
+#define BLUE 0x0000FF
 #define YELLOW 0xFFFF00
-#define PINK   0xFF1088
+#define PINK 0xFF1088
 #define ORANGE 0xE05800
-#define WHITE  0xFFFFFF
-#define BLACK  0x000000
+#define WHITE 0xFFFFFF
+#define BLACK 0x000000
 
 // Animation configs.
-const double kLedRefreshFreq = 50;  // Hz
-const double kVerticalRotationFreq = 0.5;  // Hz
-const double kPolarRotationFreq = 1.0;  // Hz
-const double kRainbowLightnessFreq = 0.5;  // Hz
-const double kRainbowHueFreq = 0.01;  // Hz
+const double kLedRefreshFreq = 50;        // Hz
+const double kVerticalRotationFreq = 0.5; // Hz
+const double kPolarRotationFreq = 1.0;    // Hz
+const double kRainbowLightnessFreq = 0.5; // Hz
+const double kRainbowHueFreq = 0.01;      // Hz
 
 // Palette configs.
 const unsigned int kMaxHue = 360;
@@ -27,22 +27,21 @@ const double kMidLightness = 50.0;
 const double kLowLightness = 25.0;
 const double kHighLightness = 75.0;
 
-
-
 // Dwelling measurements and architecture.
-const int kTopStripLen = 50;
-const int kMidStripLen = 412;
-const int kAugMidStripLen = kMidStripLen + kMidStripLen / 5;
-const int kUpperVerticalStripLen = 40;
-const int kLowerVerticalStripLen = 100;
-const int kVerticalStripLen = kUpperVerticalStripLen + kLowerVerticalStripLen;
-const int kLedsPerStrip = kAugMidStripLen;
+#define kTopStripLen 50
+#define kMidStripLen 412
+#define kAugMidStripLen (kMidStripLen + kMidStripLen / 5)
+#define kUpperVerticalStripLen 40
+#define kLowerVerticalStripLen 100
+#define kVerticalStripLen (kUpperVerticalStripLen + kLowerVerticalStripLen)
+#define kLedsPerStrip kAugMidStripLen
 
-const int kVerticalStripCount = 6;
-const int kMidStripIndex = kVerticalStripCount;
-const int kTopStripIndex = kVerticalStripCount + 1;
+#define kVerticalStripCount 6
+#define kMidStripIndex kVerticalStripCount
+#define kTopStripIndex (kVerticalStripCount + 1)
+#define NUM_LEDS (kLedsPerStrip * 6)
 
 const double kUpperHeightRatio = 0.1;
-const double kStripPolarPositions[6] = {0, 1/6, 2/6, 3/6, 4/6, 5/6};
+const double kStripPolarPositions[6] = {0, 1 / 6, 2 / 6, 3 / 6, 4 / 6, 5 / 6};
 
 #endif

--- a/main/rainbow_wave.ino
+++ b/main/rainbow_wave.ino
@@ -13,21 +13,21 @@ void WaveLightness(const double lightness_freq,
   for (double lightness = min_lightness; lightness < max_lightness;
       lightness += lightness_delta) {
     const int color = hsl2rgb(hue, kSaturation, lightness);
-    for (int i = 0; i < leds.numPixels(); i++) {
-      leds.setPixel(i, color);
+    for (int i = 0; i < NUM_LEDS; i++) {
+      leds[i] = color;
     }
-    leds.show();
-    delayMicroseconds(1000000 / refresh_freq);
+    FastLED.show();
+    FastLED.delay(1000 / refresh_freq);
   }
   // Light down;
   for (double lightness = max_lightness; lightness > min_lightness;
       lightness -= lightness_delta) {
     const int color = hsl2rgb(hue, kSaturation, lightness);
-    for (int i = 0; i < leds.numPixels(); i++) {
-      leds.setPixel(i, color);
+    for (int i = 0; i < NUM_LEDS; i++) {
+      leds[i] = color;
     }
-    leds.show();
-    delayMicroseconds(1000000 / refresh_freq);
+    FastLED.show();
+    FastLED.delay(1000 / refresh_freq);
   }
 }
 

--- a/main/rotate_polar.ino
+++ b/main/rotate_polar.ino
@@ -12,7 +12,7 @@ void ShiftPolar(const std::vector<int>& colors,
     const int color_index =
       (int) (color_shift + kStripPolarPositions[led_strip] * colors_len) % colors_len;
     for (int led_index = 0; led_index < kVerticalStripLen; led_index++) {
-      leds.setPixel(led_index + led_offset_vertical, colors[color_index]);
+      leds[led_index + led_offset_vertical] = colors[color_index];
     }
   }
   // Set color for the mid strip.
@@ -21,7 +21,7 @@ void ShiftPolar(const std::vector<int>& colors,
   for (int led_index = 0; led_index < kMidStripLen; led_index++) {
     const int color_index =
       (int) (color_shift + led_index * proj_factor_mid) % colors_len;
-    leds.setPixel(led_index + led_offset_mid, colors[color_index]);
+    leds[led_index + (int)led_offset_mid] = colors[color_index];
   }
   // Set color for the top strip.
   const double proj_factor_top = colors_len / kTopStripLen;
@@ -29,7 +29,7 @@ void ShiftPolar(const std::vector<int>& colors,
   for (int led_index = 0; led_index < kTopStripLen; led_index++) {
     const int color_index =
       (int) (color_shift + led_index * proj_factor_top) % colors_len;
-    leds.setPixel(led_index + led_offset_top, colors[color_index]);
+    leds[led_index + (int)led_offset_top] = colors[color_index];
   }
 }
 
@@ -44,15 +44,15 @@ void RotatePolar(const double rotate_freq,
     for (double color_shift = 0; color_shift < colors_len;
         color_shift += color_delta) {
       ShiftPolar(colors, color_shift);
-      leds.show();
-      delayMicroseconds(1000000 / refresh_freq);
+      FastLED.show();
+      FastLED.delay(1000 / refresh_freq);
     }
   } else {
     for (double color_shift = colors_len; color_shift > 0;
         color_shift -= color_delta) {
       ShiftPolar(colors, color_shift);
-      leds.show();
-      delayMicroseconds(1000000 / refresh_freq);
+      FastLED.show();
+      FastLED.delay(1000 / refresh_freq);
     }
   }
 }

--- a/main/rotate_vertical.ino
+++ b/main/rotate_vertical.ino
@@ -15,7 +15,7 @@ void ShiftVertical(const std::vector<int>& colors,
     for (int led_index = 0; led_index < kUpperVerticalStripLen; led_index++) {
       const int color_index =
         (int) (color_shift + led_index * proj_factor_upper) % colors_len;
-      leds.setPixel(led_index + led_offset_upper, colors[color_index]);
+      leds[led_index + led_offset_upper] = colors[color_index];
     }
     // Lower segment.
     const double proj_factor_lower =
@@ -27,7 +27,7 @@ void ShiftVertical(const std::vector<int>& colors,
     for (int led_index = 0; led_index < kLowerVerticalStripLen; led_index++) {
       const int color_index =
         (int) (color_shift_lower + led_index * proj_factor_lower) % colors_len;
-      leds.setPixel(led_index + led_offset_lower, colors[color_index]);
+      leds[led_index + led_offset_lower] = colors[color_index];
     }
   }
   // Set color for the mid strip.
@@ -35,14 +35,14 @@ void ShiftVertical(const std::vector<int>& colors,
   const int color_index_mid =
     (int) (color_shift + kUpperHeightRatio * colors_len) % colors_len;
   for (int led_index = 0; led_index < kMidStripLen; led_index++) {
-    leds.setPixel(led_index + led_offset_mid, colors[color_index_mid]);
+    leds[led_index + led_offset_mid] = colors[color_index_mid];
   }
   // Set color for the top strip.
   const int led_offset_top = kTopStripIndex * kLedsPerStrip;
   const int color_index_top =
     (int) (color_shift) % colors_len;
   for (int led_index = 0; led_index < kTopStripLen; led_index++) {
-    leds.setPixel(led_index + led_offset_top, colors[color_index_top]);
+    leds[led_index + led_offset_top] = colors[color_index_top];
   }
 }
 
@@ -57,15 +57,15 @@ void RotateVertical(const double rotate_freq,
     for (double color_shift = 0; color_shift < colors_len;
         color_shift += color_delta) {
       ShiftVertical(colors, color_shift);
-      leds.show();
-      delayMicroseconds(1000000 / refresh_freq);
+      FastLED.show();
+      FastLED.delay(1000 / refresh_freq);
     }
   } else {
     for (double color_shift = colors_len; color_shift > 0;
         color_shift -= color_delta) {
       ShiftVertical(colors, color_shift);
-      leds.show();
-      delayMicroseconds(1000000 / refresh_freq);
+      FastLED.show();
+      FastLED.delay(1000 / refresh_freq);
     }
   }
 }


### PR DESCRIPTION
@omidm I realised its quite easily possible to modify the existing code you have to use FastLED as a driver for OctoWS2811 using the OctoWS811 controller in FastLED.

If you can get this PR integrated then you'll get temporal dithering and power management functions of FastLED so you can get smooth colors and fades without having to be at 100% brightness. In theory this should just work, but I can't test it obviously, the rest of the code remains largely the same all we're really doing is changing to array index access for the led buffer, and using the FastLED show and delay functions to allow it to do temporal dithering. This should also save you some runtime since the FastLED functions are faster (https://github.com/FastLED/FastLED/wiki/Parallel-Output#making-octows2811-faster-with-fastled)

There's potentially a few problems in this PR, the compiler is warning about array subscript being above bounds in a bunch of places. This I think is due to the use of double math with cast conversions to integers all over the place. I think this is probably not a great idea as double math is usually really slow, and the cast to int is going to lead to some weird results. You might want to take a look at the 16 bit linear interpolation functions here (e.g. lerp16by16) if this causes problems: http://fastled.io/docs/3.1/group__lib8tion.html

Finally, if all this works, then try adding the power management functions and removing the brightness call: https://github.com/FastLED/FastLED/wiki/Power-notes#managing-power-in-fastled

This will then adjust brightness dynamically depending on the animation to control total overall current usage.